### PR TITLE
Add runnable Atlas v1.7 3D viewer and clear local access instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,25 @@ EN:I’m Mike, a creative explorer in the AI universe, blending art, imagination
 PT-BR:O uso das imagens e prompts é livre para estudo e inspiração, mas é gentilmente solicitado que seja dado crédito.
 
 EN:The use of images and prompts is free for study and inspiration, but credit is kindly requested.
+
+## 🔷 Visualizador 3D (Atlas v1.7)
+
+Se você quiser abrir o “molde 3D” localmente, use o arquivo:
+
+- `atlas-v1.7-cubo-integrado.html`
+
+### Como acessar
+
+1. No terminal, dentro da pasta do projeto, rode:
+   - `python3 -m http.server 8000`
+2. No navegador, abra:
+   - `http://localhost:8000/atlas-v1.7-cubo-integrado.html`
+
+### O que você vai ver
+
+- Núcleo `CORE` no centro
+- Cubo translúcido (wireframe)
+- Nós primários, médios e externos
+- Linhas de conexão com destaque ao passar o mouse
+- Pulsos de energia nas conexões
+

--- a/REVIEW-atlas-v1.7-cubo-integrado.md
+++ b/REVIEW-atlas-v1.7-cubo-integrado.md
@@ -1,0 +1,90 @@
+# Revisão técnica — Atlas v1.7 Cubo Integrado
+
+## O que esse código é
+
+Este HTML cria uma visualização 3D interativa com **Three.js** contendo:
+
+- Um **CORE** central (esfera magenta).
+- Um **cubo wireframe** translúcido ao redor.
+- 4 nós **PRIMARY** e 4 nós **MEDIUM** com cores base.
+- 2 nós **externos** (`E1`, `E2`).
+- **Conexões** em linha entre nós (core/primary/medium/externos).
+- **OrbitControls** para rotação com mouse.
+- **Raycasting de hover** para destacar conexões.
+- **Partículas de energia** (pulsos) que percorrem as conexões quando há hover.
+
+---
+
+## O que está bom
+
+- Estrutura geral clara e organizada por blocos (`SCENE`, `CAMERA`, `LIGHT`, etc.).
+- Separação razoável por funções (`createLabel`, `createConnection`, `createExternalNode`, `createPulse`).
+- Interação de hover funcionando de forma direta.
+- Resize responsivo da câmera/renderizador.
+
+---
+
+## O que precisa ajustar (prioridade alta)
+
+1. **Acúmulo excessivo de partículas (risco de queda de FPS)**
+   - `createPulse` é chamado sempre que há hover, em todo frame, para cada conexão relevante.
+   - Em 60 FPS, isso pode gerar centenas de meshes rapidamente.
+   - **Ajuste recomendado:** adicionar _throttle_ por conexão (ex.: 1 pulso a cada 120–200ms) ou limite global de partículas.
+
+2. **Remoção de partículas usando `splice` dentro de `forEach`**
+   - Modificar array durante `forEach` pode pular elementos.
+   - **Ajuste recomendado:** iterar de trás para frente com `for (let i = arr.length - 1; i >= 0; i--)`.
+
+3. **Possível vazamento de memória em recursos WebGL**
+   - Ao remover pulso da cena, geometria/material não são descartados.
+   - **Ajuste recomendado:** chamar `geometry.dispose()` e `material.dispose()` quando remover cada pulso.
+
+4. **Conexões não acompanham nós se posições mudarem no futuro**
+   - `BufferGeometry` das linhas é criada com pontos fixos.
+   - Atualmente os nós não se movem, então ok, mas limita evolução.
+   - **Ajuste recomendado:** guardar referência de atributos de posição e atualizar no loop se houver animação de nós.
+
+---
+
+## Melhorias recomendadas (média prioridade)
+
+1. **Compatibilidade de versão do Three.js**
+   - CDN fixa em `0.128.0` (antiga).
+   - **Ajuste recomendado:** atualizar para versão recente e migrar `OrbitControls` para módulo ES (`three/addons/...`) com build por bundler ou importmap.
+
+2. **Qualidade de texto dos labels**
+   - Canvas fixo pode ficar borrado em telas high-DPI.
+   - **Ajuste recomendado:** usar `window.devicePixelRatio` para dimensionar o canvas e manter nitidez.
+
+3. **Legibilidade em fundo escuro**
+   - Labels e linhas com opacidade baixa podem ficar fracos.
+   - **Ajuste recomendado:** aplicar contorno/sombra no texto e elevar opacidade mínima das linhas (ex.: 0.35).
+
+4. **Interação em dispositivos touch**
+   - Hover por `mousemove` não existe em touch.
+   - **Ajuste recomendado:** suporte a `pointermove`/`pointerdown` e seleção por toque.
+
+5. **Controle de zoom/pan**
+   - Pan desativado, zoom permitido sem limite.
+   - **Ajuste recomendado:** definir `controls.minDistance` e `controls.maxDistance` para UX previsível.
+
+---
+
+## Melhorias opcionais (baixa prioridade)
+
+- Adicionar `AmbientLight` suave para melhor profundidade visual.
+- Nomear conexões por tipo (`core-primary`, `medium-primary`, etc.) para debugging.
+- Modularizar em classes/arquivos (`GraphScene`, `InteractionController`, etc.) se o projeto crescer.
+- Exibir tooltip/overlay HTML com metadados do nó ativo.
+
+---
+
+## Exemplo rápido de correção crítica (pulsos)
+
+Ideia resumida:
+
+- Incluir `lastPulseAt` em cada conexão.
+- No `highlightConnections`, só criar novo pulso se `Date.now() - lastPulseAt > 150`.
+- No loop de partículas, remover de trás para frente e fazer `dispose` de material/geometria.
+
+Isso sozinho já tende a melhorar bastante a performance e estabilidade.

--- a/atlas-v1.7-cubo-integrado.html
+++ b/atlas-v1.7-cubo-integrado.html
@@ -1,0 +1,250 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Atlas v1.7 Cubo Integrado</title>
+  <style>
+    body { margin: 0; overflow: hidden; background: #0b1020; }
+    canvas { display: block; }
+  </style>
+</head>
+<body>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/build/three.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+
+  <script>
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x0b1020);
+
+    const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+    camera.position.z = 8;
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    document.body.appendChild(renderer.domElement);
+
+    const controls = new THREE.OrbitControls(camera, renderer.domElement);
+    controls.enablePan = false;
+    controls.enableDamping = true;
+    controls.dampingFactor = 0.05;
+    controls.minDistance = 4;
+    controls.maxDistance = 16;
+
+    const light = new THREE.PointLight(0xffffff, 1.2);
+    light.position.set(3, 3, 4);
+    scene.add(light);
+
+    const ambient = new THREE.AmbientLight(0xffffff, 0.2);
+    scene.add(ambient);
+
+    const cubeGeometry = new THREE.BoxGeometry(4, 4, 4);
+    const cubeEdges = new THREE.EdgesGeometry(cubeGeometry);
+    const cubeMaterial = new THREE.LineBasicMaterial({ color: 0x00ffff, transparent: true, opacity: 0.35 });
+    const cube = new THREE.LineSegments(cubeEdges, cubeMaterial);
+    scene.add(cube);
+
+    function createLabel(text, parent) {
+      const dpr = Math.max(1, window.devicePixelRatio || 1);
+      const canvas = document.createElement("canvas");
+      canvas.width = 256 * dpr;
+      canvas.height = 128 * dpr;
+
+      const ctx = canvas.getContext("2d");
+      ctx.scale(dpr, dpr);
+      ctx.font = "Bold 40px Arial";
+      ctx.fillStyle = "#00ffff";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.shadowColor = "rgba(0,0,0,0.8)";
+      ctx.shadowBlur = 8;
+      ctx.fillText(text, 128, 64);
+
+      const texture = new THREE.CanvasTexture(canvas);
+      texture.needsUpdate = true;
+      const material = new THREE.SpriteMaterial({ map: texture, transparent: true });
+      const sprite = new THREE.Sprite(material);
+
+      sprite.scale.set(1.5, 0.75, 1);
+      sprite.position.set(0, 0.6, 0);
+      parent.add(sprite);
+    }
+
+    const core = new THREE.Mesh(
+      new THREE.SphereGeometry(0.5, 32, 32),
+      new THREE.MeshBasicMaterial({ color: 0xff00ff })
+    );
+    scene.add(core);
+    createLabel("CORE", core);
+
+    const primaryNodes = [];
+    const mediumNodes = [];
+    const connections = [];
+    const energyParticles = [];
+
+    const baseColors = [0x00ffcc, 0xff6600, 0x66ff00, 0xff0066];
+    const rPrimary = 3;
+    const rMedium = 6;
+
+    function createConnection(objA, objB, color) {
+      const points = [objA.position.clone(), objB.position.clone()];
+      const geo = new THREE.BufferGeometry().setFromPoints(points);
+      const mat = new THREE.LineBasicMaterial({ color, transparent: true, opacity: 0.35 });
+      const line = new THREE.Line(geo, mat);
+      scene.add(line);
+
+      connections.push({
+        line,
+        start: objA,
+        end: objB,
+        baseColor: color,
+        lastPulseAt: 0,
+      });
+    }
+
+    function createExternalNode(name, color, x, y, z) {
+      const node = new THREE.Mesh(
+        new THREE.SphereGeometry(0.3, 32, 32),
+        new THREE.MeshBasicMaterial({ color })
+      );
+      node.position.set(x, y, z);
+      node.userData = { baseColor: color };
+      scene.add(node);
+      createLabel(name, node);
+      return node;
+    }
+
+    baseColors.forEach((color, i) => {
+      const number = i + 1;
+      const angle = (i / baseColors.length) * Math.PI * 2;
+
+      const primary = new THREE.Mesh(
+        new THREE.SphereGeometry(0.25, 32, 32),
+        new THREE.MeshBasicMaterial({ color })
+      );
+      primary.position.set(Math.cos(angle) * rPrimary, Math.sin(angle) * rPrimary, Math.sin(angle * 2));
+      primary.userData = { baseColor: color };
+      scene.add(primary);
+      primaryNodes.push(primary);
+      createLabel(String(number), primary);
+
+      const medium = new THREE.Mesh(
+        new THREE.SphereGeometry(0.18, 32, 32),
+        new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.6 })
+      );
+      medium.position.set(Math.cos(angle) * rMedium, Math.sin(angle) * rMedium, Math.sin(angle * 2));
+      medium.userData = { baseColor: color };
+      scene.add(medium);
+      mediumNodes.push(medium);
+      createLabel(number + ".01", medium);
+
+      createConnection(primary, core, color);
+      createConnection(medium, primary, color);
+    });
+
+    const externalA = createExternalNode("E1", 0x00ffff, 5, 2, -3);
+    const externalB = createExternalNode("E2", 0xff00ff, 7, -1, -4);
+
+    createConnection(externalA, core, 0x00ffff);
+    createConnection(externalB, core, 0xff00ff);
+    createConnection(externalA, externalB, 0xffffff);
+
+    const raycaster = new THREE.Raycaster();
+    const mouse = new THREE.Vector2(9999, 9999);
+    let hovered = null;
+
+    function updatePointer(event) {
+      mouse.x = (event.clientX / window.innerWidth) * 2 - 1;
+      mouse.y = -(event.clientY / window.innerHeight) * 2 + 1;
+    }
+
+    window.addEventListener("pointermove", updatePointer);
+
+    function createPulse(start, end, color) {
+      const pulse = new THREE.Mesh(
+        new THREE.SphereGeometry(0.07, 16, 16),
+        new THREE.MeshBasicMaterial({ color })
+      );
+
+      pulse.userData = {
+        start: start.clone(),
+        end: end.clone(),
+        progress: 0,
+      };
+
+      scene.add(pulse);
+      energyParticles.push(pulse);
+    }
+
+    function checkHover() {
+      raycaster.setFromCamera(mouse, camera);
+      const intersects = raycaster.intersectObjects([...primaryNodes, ...mediumNodes, externalA, externalB]);
+
+      if (intersects.length > 0) {
+        const obj = intersects[0].object;
+        if (hovered !== obj) {
+          resetConnections();
+          hovered = obj;
+        }
+        highlightConnections(obj);
+      } else {
+        hovered = null;
+        resetConnections();
+      }
+    }
+
+    function highlightConnections(obj) {
+      const now = Date.now();
+      const pulseInterval = 160;
+      const maxParticles = 180;
+
+      connections.forEach((c) => {
+        if (c.start === obj || c.end === obj) {
+          c.line.material.opacity = 1;
+
+          if (energyParticles.length < maxParticles && now - c.lastPulseAt >= pulseInterval) {
+            createPulse(c.start.position, c.end.position, c.baseColor);
+            c.lastPulseAt = now;
+          }
+        }
+      });
+    }
+
+    function resetConnections() {
+      connections.forEach((c) => {
+        c.line.material.opacity = 0.35;
+      });
+    }
+
+    function animate() {
+      requestAnimationFrame(animate);
+      checkHover();
+
+      for (let i = energyParticles.length - 1; i >= 0; i--) {
+        const p = energyParticles[i];
+        p.userData.progress += 0.02;
+
+        if (p.userData.progress >= 1) {
+          scene.remove(p);
+          p.geometry.dispose();
+          p.material.dispose();
+          energyParticles.splice(i, 1);
+        } else {
+          p.position.lerpVectors(p.userData.start, p.userData.end, p.userData.progress);
+        }
+      }
+
+      controls.update();
+      renderer.render(scene, camera);
+    }
+
+    animate();
+
+    window.addEventListener("resize", () => {
+      camera.aspect = window.innerWidth / window.innerHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(window.innerWidth, window.innerHeight);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a runnable, first‑time‑user friendly 3D “molde” so the scene can be opened and inspected locally instead of only having a review document.  
- Improve stability and performance of the interactive viewer so hover pulses and particle effects do not cause unbounded memory or FPS degradation.

### Description
- Add `atlas-v1.7-cubo-integrado.html`, a Three.js-based interactive viewer with `OrbitControls`, raycast hover highlighting, labeled nodes, and energy-pulse particles.  
- Implement pulse throttling (`lastPulseAt` + `pulseInterval`) and a global `maxParticles` cap, and perform proper WebGL cleanup (`geometry.dispose()` / `material.dispose()`) when particles are removed.  
- Improve UX with `pointermove` handling, `devicePixelRatio` aware label canvas, and `controls.minDistance` / `controls.maxDistance` limits.  
- Update `README.md` with step-by-step local access instructions (how to run `python3 -m http.server` and the direct URL) and add a technical review file `REVIEW-atlas-v1.7-cubo-integrado.md` summarizing design and improvement suggestions.

### Testing
- Started a local static server with `python3 -m http.server 8000` and confirmed the server process was launched successfully.  
- Attempted an automated headless screenshot using Playwright, but the Chromium process crashed (SIGSEGV) in this environment so the screenshot step failed.  
- Performed repository checks (status) to verify the new files are present and the workspace reflects the viewer and README updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cbf2a09fc8327b0d42f70a67de20e)